### PR TITLE
fix: call event to pull app state to client

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,11 +24,16 @@ fn open_app(path: &str) {
 }
 
 #[tauri::command]
-fn save_workflows(state: tauri::State<AppState>, config: config::Config) {
+fn save_workflows(state: tauri::State<AppState>, app: tauri::AppHandle, config: config::Config) {
   let mut app_state = state.0.lock().expect("Could not lock mutex");
   let config_as_string = serde_json::to_string(&config).expect("couldnt serialize");
+
+  // Update state
   *app_state = config_as_string;
+  // Save to file
   config::set_config(config);
+  // Instruct client
+  app.get_window("omnibar").unwrap().emit("state-updated", "");
 }
 
 #[derive(Default)]

--- a/src/Omnibar.tsx
+++ b/src/Omnibar.tsx
@@ -4,24 +4,38 @@ import { useEffect, useState } from "react";
 import { Action, Autocomplete } from "./components/Autocomplete";
 import { getConfig } from "./utils";
 
+enum AppEvents {
+  OmnibarFocused = "omnibar-focus",
+  AppStateUpdated = "state-updated",
+}
+
 const focusSearchBar = () => {
   let input = document.querySelector(".aa-Input") as HTMLElement | null;
   input?.focus();
 };
 const Omnibar = () => {
   const [suggestions, setSuggestions] = useState<string[]>([]);
+  async function setStoredConfigChoices() {
+    let state = await getConfig();
+    setSuggestions(state.workflows.map((wf) => wf.name));
+  }
   useEffect(() => {
-    const unlisten = appWindow.listen("omnibar-focus", focusSearchBar);
+    const unlisten1 = appWindow.listen(
+      AppEvents.OmnibarFocused,
+      focusSearchBar
+    );
+    const unlisten2 = appWindow.listen(
+      AppEvents.AppStateUpdated,
+      setStoredConfigChoices
+    );
 
     return () => {
-      unlisten();
+      unlisten1();
+      unlisten2();
     };
   }, []);
+
   useEffect(() => {
-    async function setStoredConfigChoices() {
-      let state = await getConfig();
-      setSuggestions(state.workflows.map((wf) => wf.name));
-    }
     setStoredConfigChoices();
   }, []);
 


### PR DESCRIPTION
Create a window message to trigger `omnibar` client state updates.

There's a cleaner fix where we just send the new state, but there's some refactoring first.