### PR TITLE
feat(build): Add Code signing to build process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,10 +38,10 @@ jobs:
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
         run: |
           New-Item -ItemType directory -Path certificate
-          Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_PFX
+          Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_CERTIFICATE
           certutil -decode certificate/tempCert.txt certificate/certificate.pfx
           Remove-Item -path certificate -include tempCert.txt
-          Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)
+          Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_CERTIFICATE_PASSWORD -Force -AsPlainText)
       - name: install app dependencies and build it
         run: npm install && npm run build
       - uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,17 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
+      - name: import windows certificate
+        if: matrix.platform == 'windows-latest'
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
+        run: |
+          New-Item -ItemType directory -Path certificate
+          Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_PFX
+          certutil -decode certificate/tempCert.txt certificate/certificate.pfx
+          Remove-Item -path certificate -include tempCert.txt
+          Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)
       - name: install app dependencies and build it
         run: npm install && npm run build
       - uses: tauri-apps/tauri-action@v0

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,7 +46,7 @@
       },
       "windows": {
         "certificateThumbprint": "C8577E1A7317EF59589BFD88C1E4B96D4A80B7CF",
-        "digestAlgorithm": "sha256",
+        "digestAlgorithm": "sha384",
         "timestampUrl": ""
       }
     },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,7 +45,7 @@
         "entitlements": null
       },
       "windows": {
-        "certificateThumbprint": null,
+        "certificateThumbprint": "C8577E1A7317EF59589BFD88C1E4B96D4A80B7CF",
         "digestAlgorithm": "sha256",
         "timestampUrl": ""
       }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,7 +47,7 @@
       "windows": {
         "certificateThumbprint": "C8577E1A7317EF59589BFD88C1E4B96D4A80B7CF",
         "digestAlgorithm": "sha384",
-        "timestampUrl": ""
+        "timestampUrl": "http://timestamp.digicert.com"
       }
     },
     "updater": {


### PR DESCRIPTION
## On My Local Machine

* Downloaded the `.cer` file from Digicert
* Installed it in my local
* Used the digicert utils to export a PFX (and gave it the password)
* Used `cerutil` to turn the `.pfx` into a `.txt` file 
* Got the cert thumbprint and algorithm from my machine

## In the Repo

* Added github secrets with the content of the cert text file and the password
* Added thumbprint, algorithm, and timestamp to the tauri conf file
* Added GitHub actions steps from the [Tauri Docs](https://tauri.studio/docs/distribution/sign-windows#bonus-sign-your-application-with-github-actions)
* Fixed the Action, (and submitted https://github.com/tauri-apps/tauri-docs/pull/505 upstream to fix it)