### PR TITLE
Signing for Mac & PR builds

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,5 @@
-name: "publish"
-on:
-  push:
-    branches:
-      - main
+name: "PR build"
+on: [pull_request]
 
 jobs:
   publish-tauri:
@@ -53,9 +50,3 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-        with:
-          tagName: brancato-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
-          releaseName: "Brancato v__VERSION__"
-          releaseBody: "See the assets to download this version and install."
-          releaseDraft: true
-          prerelease: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brancato",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "brancato",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.5.3",
         "@algolia/autocomplete-theme-classic": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brancato",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "dependencies": {
     "@algolia/autocomplete-js": "^1.5.3",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "brancato"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "directories",
  "execute",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brancato"
-version = "0.7.0"
+version = "0.7.1"
 description = "A tool for stage-managing your life"
 authors = ["Ryan Killeen"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "package": {
     "productName": "brancato",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "build": {
     "distDir": "../build",


### PR DESCRIPTION
Resolves #50 (I think/hope)

Per https://tauri.studio/docs/distribution/sign-macos.

## On My Local (Windows)

* Created cert on apple dev portal
* Created app specific password for my account for signing
* Downloaded the certificate
* Exported a PFX file on windows (and renamed to p12; apparently they're the same format. We'll see.)
* Encoded a text file of the cert
* Added the signing identity (full name on the cert entry), my apple id, the app password for the account, the text of the cert, and the cert password, etc. to secrets for GitHub actions.

## In this PR

* Added the env variables to the build process

ℹ️ Note that in the Tauri docs example here, it assumes only a macos build. It's possible that adding these variables in all matrixed builds may screw things up at first and we may need to find a way to wrap them in an if statement or two separate build steps based on matrix (or Tauri may be smart enough to pick that up.)